### PR TITLE
feat: Add DatePicker for editing task due dates

### DIFF
--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -7,7 +7,9 @@ import htmlToDraft from 'html-to-draftjs';
 import DOMPurify from 'dompurify';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import { AiFillEdit, AiFillSave } from 'react-icons/ai';
-import { FaTrash, FaCommentDots } from 'react-icons/fa';
+import { FaTrash, FaCommentDots, FaCalendarAlt } from 'react-icons/fa';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import ConfirmModal from 'components/ConfirmModal';
 import styles from 'styles/TodoItem.module.css';
 import ReminderSettings from './ReminderSettings';
@@ -19,6 +21,8 @@ const TodoItem = ({
 }) => {
   const [editing, setEditing] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [editingDueDate, setEditingDueDate] = useState(false);
+  const [tempDueDate, setTempDueDate] = useState(null);
   const [editorState, setEditorState] = useState(() => {
     let contentState;
     try {
@@ -64,6 +68,33 @@ const TodoItem = ({
 
   const handleCommentSave = () => {
     setActiveCommentId(null);
+  };
+
+  const handleEditDueDate = () => {
+    // Prepare current due date as a Date object for react-datepicker
+    if (itemProp.dueDate) {
+      setTempDueDate(new Date(itemProp.dueDate));
+    } else {
+      setTempDueDate(null);
+    }
+    setEditingDueDate(true);
+  };
+
+  const handleSaveDueDate = () => {
+    if (tempDueDate) {
+      const updatedTodo = { ...itemProp, dueDate: new Date(tempDueDate).toISOString() };
+      setUpdate(updatedTodo.title, itemProp.id, updatedTodo.dueDate);
+    } else {
+      // clear due date
+      setUpdate(itemProp.title, itemProp.id, null);
+    }
+    setEditingDueDate(false);
+    setTempDueDate(null);
+  };
+
+  const handleCancelDueDate = () => {
+    setEditingDueDate(false);
+    setTempDueDate(null);
   };
 
   const handleDelete = () => {
@@ -150,7 +181,7 @@ const TodoItem = ({
         <span style={itemProp.completed ? completedStyle : null}>
           {/* eslint-disable-next-line */}
           <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(itemProp.title) }} />
-          {itemProp.dueDate && (
+          {!editingDueDate && itemProp.dueDate && (
             <span className={styles.dueDate}>
               {' '}
               Due:
@@ -161,6 +192,62 @@ const TodoItem = ({
                 hour: 'numeric',
                 minute: '2-digit',
               })}
+              <button
+                type="button"
+                onClick={handleEditDueDate}
+                className={styles.editDueDateBtn}
+                title="Edit due date"
+                aria-label="Edit due date"
+              >
+                <FaCalendarAlt />
+              </button>
+            </span>
+          )}
+          {!editingDueDate && !itemProp.dueDate && (
+            <button
+              type="button"
+              onClick={handleEditDueDate}
+              className={styles.addDueDateBtn}
+              title="Add due date"
+              aria-label="Add due date"
+            >
+              <FaCalendarAlt />
+              {' '}
+              Add due date
+            </button>
+          )}
+          {editingDueDate && (
+            <span className={styles.dueDateEditor}>
+              <DatePicker
+                selected={tempDueDate}
+                onChange={(date) => setTempDueDate(date)}
+                showTimeSelect
+                timeFormat="HH:mm"
+                timeIntervals={15}
+                dateFormat="MMM d, yyyy h:mm aa"
+                placeholderText="Set due date & time"
+                className={styles.dueDateInput}
+                minDate={new Date()}
+                isClearable
+              />
+              <button
+                type="button"
+                onClick={handleSaveDueDate}
+                className={styles.saveDueDateBtn}
+                title="Save due date"
+                aria-label="Save due date"
+              >
+                <AiFillSave />
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelDueDate}
+                className={styles.cancelDueDateBtn}
+                title="Cancel"
+                aria-label="Cancel editing due date"
+              >
+                ✕
+              </button>
             </span>
           )}
         </span>

--- a/src/components/TodosLogic.jsx
+++ b/src/components/TodosLogic.jsx
@@ -186,11 +186,15 @@ const TodosLogic = ({
     }));
   };
 
-  const setUpdate = (updatedTitle, id) => {
+  const setUpdate = (updatedTitle, id, updatedDueDate) => {
     setTodos(
       todos.map((todo) => {
         if (todo.id === id) {
-          return ({ ...todo, title: updatedTitle });
+          const updates = { ...todo, title: updatedTitle };
+          if (updatedDueDate !== undefined) {
+            updates.dueDate = updatedDueDate;
+          }
+          return updates;
         }
         return todo;
       }),

--- a/src/styles/TodoItem.module.css
+++ b/src/styles/TodoItem.module.css
@@ -76,6 +76,97 @@
   background: #f3f3f3;
   padding: 2px 8px;
   border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.editDueDateBtn {
+  background: transparent !important;
+  border: none !important;
+  color: #dc4c3e !important;
+  font-size: 14px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  cursor: pointer;
+  display: inline-flex !important;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.editDueDateBtn:hover {
+  transform: scale(1.2);
+}
+
+.addDueDateBtn {
+  font-size: 12px;
+  color: #888;
+  background: #f3f3f3;
+  border: 1px dashed #ccc;
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-left: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: all 0.2s ease;
+}
+
+.addDueDateBtn:hover {
+  background: #e8e8e8;
+  border-color: #dc4c3e;
+  color: #dc4c3e;
+}
+
+.dueDateEditor {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+}
+
+.dueDateInput {
+  padding: 4px 8px;
+  border: 1px solid #dc4c3e;
+  border-radius: 4px;
+  font-size: 12px;
+  outline: none;
+}
+
+.saveDueDateBtn {
+  background: #dc4c3e !important;
+  color: white !important;
+  border: none !important;
+  padding: 4px 8px !important;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px !important;
+  display: inline-flex !important;
+  align-items: center;
+  transition: background 0.2s ease;
+}
+
+.saveDueDateBtn:hover {
+  background: #c43d30 !important;
+}
+
+.cancelDueDateBtn {
+  background: #f3f3f3 !important;
+  color: #666 !important;
+  border: none !important;
+  padding: 4px 8px !important;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px !important;
+  display: inline-flex !important;
+  align-items: center;
+  transition: background 0.2s ease;
+}
+
+.cancelDueDateBtn:hover {
+  background: #e8e8e8 !important;
+  color: #333 !important;
 }
 
 .content span span.completion {


### PR DESCRIPTION
- Replace native datetime-local input with react-datepicker in TodoItem
- Use same configuration as InputTodo (showTimeSelect, 15min intervals, minDate)
- Allow clearing due date via isClearable prop
- Consistent date/time selection UX across add and edit flows