### PR TITLE
feat: Add collaborative shared lists with task assignment

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,38 @@ service cloud.firestore {
     // userId in the path must match the authenticated user's email
     match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.token.email == userId;
+      
+      // Allow access to sharedListRefs subcollection
+      // Users can manage their own refs, AND other authenticated users can add refs
+      // (needed when inviting someone to a shared list)
+      match /sharedListRefs/{listId} {
+        // User can read/write their own refs
+        allow read, write: if request.auth != null && request.auth.token.email == userId;
+        // Any authenticated user can create a ref for another user (for invitations)
+        allow create: if request.auth != null;
+        // Any authenticated user can delete a ref (for removing members)
+        allow delete: if request.auth != null;
+      }
+    }
+    
+    // Shared lists - accessible by members
+    match /sharedLists/{listId} {
+      // Allow read if user is a member of the list
+      allow read: if request.auth != null && 
+        request.auth.token.email in resource.data.members;
+      
+      // Allow create if user is authenticated (they become owner)
+      allow create: if request.auth != null && 
+        request.auth.token.email == request.resource.data.owner &&
+        request.auth.token.email in request.resource.data.members;
+      
+      // Allow update if user is a member
+      allow update: if request.auth != null && 
+        request.auth.token.email in resource.data.members;
+      
+      // Allow delete only by owner
+      allow delete: if request.auth != null && 
+        request.auth.token.email == resource.data.owner;
     }
   }
 }

--- a/src/components/SharedListsPanel.jsx
+++ b/src/components/SharedListsPanel.jsx
@@ -1,0 +1,429 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { toast } from 'react-toastify';
+import {
+  FaPlus, FaUsers, FaChevronDown, FaTrash, FaCog, FaUser, FaList,
+} from 'react-icons/fa';
+import SharedListsService from '../firebase/sharedListsService';
+import styles from '../styles/SharedLists.module.css';
+
+const SharedListsPanel = ({
+  currentUser,
+  activeList,
+  onListSelect,
+}) => {
+  const [lists, setLists] = useState([]);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showManageModal, setShowManageModal] = useState(false);
+  const [selectedList, setSelectedList] = useState(null);
+  const [newListName, setNewListName] = useState('');
+  const [newMemberEmail, setNewMemberEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const sharedListsService = useRef(null);
+
+  // Initialize service
+  useEffect(() => {
+    if (currentUser?.email) {
+      sharedListsService.current = new SharedListsService(currentUser.email);
+
+      // Subscribe to user's shared lists
+      const unsubscribe = sharedListsService.current.subscribeToUserLists((result) => {
+        if (result.success) {
+          setLists(result.lists);
+        }
+      });
+
+      return () => unsubscribe();
+    }
+    return () => {};
+  }, [currentUser]);
+
+  const handleCreateList = async () => {
+    if (!newListName.trim()) {
+      toast.error('Please enter a list name');
+      return;
+    }
+
+    setIsLoading(true);
+    const result = await sharedListsService.current.createList(newListName.trim());
+    setIsLoading(false);
+
+    if (result.success) {
+      toast.success(`Created list "${newListName}"`);
+      setNewListName('');
+      setShowCreateModal(false);
+      // Auto-select the new list
+      onListSelect({ id: result.listId, name: newListName, type: 'shared' });
+    } else {
+      toast.error(`Failed to create list: ${result.error}`);
+    }
+  };
+
+  const handleInviteMember = async () => {
+    if (!newMemberEmail.trim()) {
+      toast.error('Please enter an email address');
+      return;
+    }
+
+    if (!selectedList) return;
+
+    setIsLoading(true);
+    const result = await sharedListsService.current.inviteMember(
+      selectedList.id,
+      newMemberEmail.trim().toLowerCase(),
+    );
+    setIsLoading(false);
+
+    if (result.success) {
+      toast.success(`Invited ${newMemberEmail} to the list`);
+      setNewMemberEmail('');
+    } else {
+      toast.error(`Failed to invite: ${result.error}`);
+    }
+  };
+
+  const handleRemoveMember = async (memberEmail) => {
+    if (!selectedList) return;
+
+    // eslint-disable-next-line no-alert
+    const confirmRemove = window.confirm(
+      `Remove ${memberEmail} from "${selectedList.name}"?`,
+    );
+    if (!confirmRemove) return;
+
+    setIsLoading(true);
+    const result = await sharedListsService.current.removeMember(
+      selectedList.id,
+      memberEmail,
+    );
+    setIsLoading(false);
+
+    if (result.success) {
+      toast.success(`Removed ${memberEmail} from the list`);
+      // If user removed themselves, close modal and switch to personal
+      if (memberEmail === currentUser?.email) {
+        setShowManageModal(false);
+        onListSelect({ id: 'personal', name: 'My Tasks', type: 'personal' });
+      }
+    } else {
+      toast.error(`Failed to remove member: ${result.error}`);
+    }
+  };
+
+  const handleDeleteList = async () => {
+    if (!selectedList) return;
+
+    // eslint-disable-next-line no-alert
+    const confirmDelete = window.confirm(
+      `Delete "${selectedList.name}"? This will remove all tasks and cannot be undone.`,
+    );
+    if (!confirmDelete) return;
+
+    setIsLoading(true);
+    const result = await sharedListsService.current.deleteList(selectedList.id);
+    setIsLoading(false);
+
+    if (result.success) {
+      toast.success(`Deleted list "${selectedList.name}"`);
+      setShowManageModal(false);
+      // Switch to personal list
+      onListSelect({ id: 'personal', name: 'My Tasks', type: 'personal' });
+    } else {
+      toast.error(`Failed to delete list: ${result.error}`);
+    }
+  };
+
+  const openManageModal = (list, e) => {
+    e.stopPropagation();
+    setSelectedList(list);
+    setShowManageModal(true);
+  };
+
+  if (!currentUser) {
+    return null;
+  }
+
+  return (
+    <div className={styles.sharedListsPanel}>
+      <button
+        type="button"
+        className={styles.toggleButton}
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <span>📋 Lists</span>
+        <FaChevronDown className={`${styles.toggleIcon} ${isExpanded ? styles.open : ''}`} />
+      </button>
+
+      <div className={`${styles.panelContent} ${!isExpanded ? styles.collapsed : ''}`}>
+        <div className={styles.header}>
+          <h3>Your Lists</h3>
+          <button
+            type="button"
+            className={styles.createButton}
+            onClick={() => setShowCreateModal(true)}
+          >
+            <FaPlus />
+            New List
+          </button>
+        </div>
+
+        <div className={styles.listContainer}>
+          {/* Personal List (always shown) */}
+          <div
+            role="button"
+            tabIndex={0}
+            className={`${styles.listItem} ${styles.personal} ${activeList?.id === 'personal' ? styles.active : ''}`}
+            onClick={() => onListSelect({ id: 'personal', name: 'My Tasks', type: 'personal' })}
+            onKeyDown={(e) => e.key === 'Enter' && onListSelect({ id: 'personal', name: 'My Tasks', type: 'personal' })}
+          >
+            <div className={styles.listInfo}>
+              <FaUser className={styles.listIcon} style={{ color: '#2196f3' }} />
+              <div className={styles.listDetails}>
+                <span className={styles.listName}>My Tasks</span>
+                <span className={styles.listMeta}>Personal</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Shared Lists */}
+          {lists.map((list) => (
+            <div
+              key={list.id}
+              role="button"
+              tabIndex={0}
+              className={`${styles.listItem} ${activeList?.id === list.id ? styles.active : ''}`}
+              onClick={() => onListSelect({ id: list.id, name: list.name, type: 'shared' })}
+              onKeyDown={(e) => e.key === 'Enter' && onListSelect({ id: list.id, name: list.name, type: 'shared' })}
+            >
+              <div className={styles.listInfo}>
+                <FaList className={styles.listIcon} style={{ color: '#dc4c3e' }} />
+                <div className={styles.listDetails}>
+                  <span className={styles.listName}>{list.name}</span>
+                  <span className={styles.listMeta}>
+                    <span className={styles.memberCount}>
+                      <FaUsers />
+                      {list.members?.length || 1}
+                    </span>
+                    {list.owner === currentUser?.email && (
+                      <span className={styles.ownerBadge}>Owner</span>
+                    )}
+                  </span>
+                </div>
+              </div>
+              <div className={styles.listActions}>
+                <button
+                  type="button"
+                  className={styles.actionButton}
+                  onClick={(e) => openManageModal(list, e)}
+                  title="Manage list"
+                >
+                  <FaCog />
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {lists.length === 0 && (
+            <div className={styles.emptyState}>
+              <p>No shared lists yet</p>
+              <button
+                type="button"
+                className={styles.createButton}
+                onClick={() => setShowCreateModal(true)}
+              >
+                <FaPlus />
+                Create your first list
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create List Modal */}
+      {showCreateModal && (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+          className={styles.modalOverlay}
+          onClick={() => setShowCreateModal(false)}
+          onKeyDown={(e) => e.key === 'Escape' && setShowCreateModal(false)}
+        >
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+          <div
+            className={styles.modal}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="createListTitle"
+          >
+            <h3 id="createListTitle">Create New List</h3>
+            <div className={styles.inputGroup}>
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label htmlFor="newListName">List Name</label>
+              <input
+                id="newListName"
+                type="text"
+                value={newListName}
+                onChange={(e) => setNewListName(e.target.value)}
+                placeholder="e.g., Work Projects, Family Tasks"
+                onKeyDown={(e) => e.key === 'Enter' && handleCreateList()}
+              />
+            </div>
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.cancelButton}
+                onClick={() => setShowCreateModal(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.submitButton}
+                onClick={handleCreateList}
+                disabled={isLoading || !newListName.trim()}
+              >
+                {isLoading ? 'Creating...' : 'Create List'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Manage List Modal */}
+      {showManageModal && selectedList && (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+          className={styles.modalOverlay}
+          onClick={() => setShowManageModal(false)}
+          onKeyDown={(e) => e.key === 'Escape' && setShowManageModal(false)}
+        >
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+          <div
+            className={styles.modal}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="manageListTitle"
+          >
+            <h3 id="manageListTitle">
+              Manage &quot;
+              {selectedList.name}
+              &quot;
+            </h3>
+
+            {/* Members Section */}
+            <div className={styles.inputGroup}>
+              <span className={styles.membersLabel}>
+                Members (
+                {selectedList.members?.length || 0}
+                )
+              </span>
+            </div>
+            <div className={styles.membersList}>
+              {selectedList.members?.map((member) => (
+                <div key={member} className={styles.memberItem}>
+                  <span className={styles.memberEmail}>
+                    {member}
+                    {member === selectedList.owner && ' (Owner)'}
+                    {member === currentUser?.email && ' (You)'}
+                  </span>
+                  {selectedList.owner === currentUser?.email && member !== selectedList.owner && (
+                    <button
+                      type="button"
+                      className={styles.removeButton}
+                      onClick={() => handleRemoveMember(member)}
+                      disabled={isLoading}
+                    >
+                      Remove
+                    </button>
+                  )}
+                  {member === currentUser?.email && member !== selectedList.owner && (
+                    <button
+                      type="button"
+                      className={styles.removeButton}
+                      onClick={() => handleRemoveMember(member)}
+                      disabled={isLoading}
+                    >
+                      Leave
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* Invite Member */}
+            <div className={styles.inputGroup}>
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label htmlFor="inviteMemberEmail">Invite Member</label>
+              <input
+                id="inviteMemberEmail"
+                type="email"
+                value={newMemberEmail}
+                onChange={(e) => setNewMemberEmail(e.target.value)}
+                placeholder="Enter email address"
+                onKeyDown={(e) => e.key === 'Enter' && handleInviteMember()}
+              />
+            </div>
+            <button
+              type="button"
+              className={styles.submitButton}
+              onClick={handleInviteMember}
+              disabled={isLoading || !newMemberEmail.trim()}
+              style={{ width: '100%', marginBottom: '16px' }}
+            >
+              {isLoading ? 'Inviting...' : 'Invite'}
+            </button>
+
+            {/* Delete List (Owner only) */}
+            {selectedList.owner === currentUser?.email && (
+              <button
+                type="button"
+                className={styles.removeButton}
+                onClick={handleDeleteList}
+                disabled={isLoading}
+                style={{ width: '100%' }}
+              >
+                <FaTrash style={{ marginRight: '8px' }} />
+                Delete List
+              </button>
+            )}
+
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.cancelButton}
+                onClick={() => setShowManageModal(false)}
+                style={{ width: '100%' }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+SharedListsPanel.propTypes = {
+  currentUser: PropTypes.shape({
+    email: PropTypes.string,
+  }),
+  activeList: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    type: PropTypes.string,
+  }),
+  onListSelect: PropTypes.func.isRequired,
+};
+
+SharedListsPanel.defaultProps = {
+  currentUser: null,
+  activeList: { id: 'personal', name: 'My Tasks', type: 'personal' },
+};
+
+export default SharedListsPanel;

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -7,7 +7,7 @@ import htmlToDraft from 'html-to-draftjs';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import { AiFillEdit, AiFillSave } from 'react-icons/ai';
 import {
-  FaTrash, FaCommentDots, FaCalendarAlt, FaGripVertical, FaEllipsisV,
+  FaTrash, FaCommentDots, FaCalendarAlt, FaGripVertical, FaEllipsisV, FaUserCircle,
 } from 'react-icons/fa';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
@@ -21,13 +21,24 @@ const TodoItem = ({
   itemProp, onChange, deleteTodo, setUpdate,
   comments, handleCommentChange, activeCommentId, setActiveCommentId,
   reminder, onSaveReminder, dragHandleProps,
+  listMembers, memberDetails, onAssign, isSharedList,
 }) => {
   const [editing, setEditing] = useState(false);
+
+  // Helper to get display name for an email
+  const getDisplayName = (email) => {
+    if (memberDetails && memberDetails[email]?.displayName) {
+      return memberDetails[email].displayName;
+    }
+    // Fallback to email prefix
+    return email ? email.split('@')[0] : 'Unknown';
+  };
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [editingDueDate, setEditingDueDate] = useState(false);
   const [tempDueDate, setTempDueDate] = useState(null);
   const [showActionsMenu, setShowActionsMenu] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+  const [showAssignMenu, setShowAssignMenu] = useState(false);
   const actionsMenuRef = useRef(null);
   const menuButtonRef = useRef(null);
   // Determine mobile viewport once per render (client-side only)
@@ -113,7 +124,9 @@ const TodoItem = ({
     if (!showActionsMenu && menuButtonRef.current) {
       const rect = menuButtonRef.current.getBoundingClientRect();
       const dropdownWidth = 180;
+      const dropdownHeight = 280; // Approximate height of the dropdown
       let leftPosition = rect.right - dropdownWidth;
+      let topPosition = rect.bottom + 4;
 
       // Ensure dropdown doesn't go off-screen on the left
       if (leftPosition < 8) {
@@ -125,8 +138,18 @@ const TodoItem = ({
         leftPosition = window.innerWidth - dropdownWidth - 8;
       }
 
+      // Ensure dropdown doesn't go off-screen on the bottom
+      if (topPosition + dropdownHeight > window.innerHeight - 8) {
+        // Position above the button instead
+        topPosition = rect.top - dropdownHeight - 4;
+        // If still off-screen at top, just position at top of viewport
+        if (topPosition < 8) {
+          topPosition = 8;
+        }
+      }
+
       setMenuPosition({
-        top: rect.bottom + 4,
+        top: topPosition,
         left: leftPosition,
       });
     }
@@ -252,6 +275,48 @@ const TodoItem = ({
                 <FaCalendarAlt style={{ color: '#666', fontSize: '16px' }} />
                 <span>Due Date</span>
               </button>
+              {isSharedList && listMembers && listMembers.length > 0 && (
+                <div className={styles.assignMenuWrapper}>
+                  <button
+                    type="button"
+                    onClick={() => setShowAssignMenu(!showAssignMenu)}
+                    title="Assign task"
+                  >
+                    <FaUserCircle style={{ color: '#666', fontSize: '16px' }} />
+                    <span>Assign</span>
+                  </button>
+                  {showAssignMenu && (
+                    <div className={styles.assignSubmenu}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onAssign(itemProp.id, null);
+                          setShowAssignMenu(false);
+                          setShowActionsMenu(false);
+                        }}
+                        className={!itemProp.assignedTo ? styles.activeAssignee : ''}
+                      >
+                        Unassigned
+                      </button>
+                      {listMembers.map((member) => (
+                        <button
+                          key={member}
+                          type="button"
+                          onClick={() => {
+                            onAssign(itemProp.id, member);
+                            setShowAssignMenu(false);
+                            setShowActionsMenu(false);
+                          }}
+                          className={itemProp.assignedTo === member ? styles.activeAssignee : ''}
+                          title={member}
+                        >
+                          {getDisplayName(member)}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
               {itemProp.dueDate && (
                 <div className={styles.reminderInMenu}>
                   <ReminderSettings
@@ -291,6 +356,12 @@ const TodoItem = ({
         )}
         <span style={itemProp.completed ? completedStyle : null}>
           <CodeBlockRenderer htmlContent={itemProp.title} />
+          {isSharedList && itemProp.assignedTo && (
+            <span className={styles.assignedBadge}>
+              <FaUserCircle />
+              {getDisplayName(itemProp.assignedTo)}
+            </span>
+          )}
           {!editingDueDate && itemProp.dueDate && (
             <span className={styles.dueDate}>
               {' '}
@@ -453,6 +524,7 @@ TodoItem.propTypes = {
     title: PropTypes.string,
     completed: PropTypes.bool,
     dueDate: PropTypes.string,
+    assignedTo: PropTypes.string,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
   deleteTodo: PropTypes.func.isRequired,
@@ -464,12 +536,22 @@ TodoItem.propTypes = {
   reminder: PropTypes.string,
   onSaveReminder: PropTypes.func.isRequired,
   dragHandleProps: PropTypes.shape({}),
+  listMembers: PropTypes.arrayOf(PropTypes.string),
+  memberDetails: PropTypes.objectOf(PropTypes.shape({
+    displayName: PropTypes.string,
+  })),
+  onAssign: PropTypes.func,
+  isSharedList: PropTypes.bool,
 };
 
 TodoItem.defaultProps = {
   activeCommentId: null,
   reminder: null,
   dragHandleProps: {},
+  listMembers: [],
+  memberDetails: {},
+  onAssign: () => {},
+  isSharedList: false,
 };
 
 export default TodoItem;

--- a/src/components/TodosList.jsx
+++ b/src/components/TodosList.jsx
@@ -6,7 +6,7 @@ import TodoItem from 'components/TodoItem';
 const TodosList = ({
   todosProps, handleChange, deleteTodo, setUpdate, moveUp, moveDown, comments,
   handleCommentChange, activeCommentId, setActiveCommentId, currentPage, totalPages, onDragEnd,
-  reminders, handleSaveReminder,
+  reminders, handleSaveReminder, listMembers, memberDetails, onAssign, isSharedList,
 }) => (
   <DragDropContext onDragEnd={onDragEnd}>
     <Droppable droppableId="todos">
@@ -42,6 +42,10 @@ const TodosList = ({
                     reminder={reminders[todo.id]}
                     onSaveReminder={handleSaveReminder}
                     dragHandleProps={provided.dragHandleProps}
+                    listMembers={listMembers}
+                    memberDetails={memberDetails}
+                    onAssign={onAssign}
+                    isSharedList={isSharedList}
                   />
                 </li>
               )}
@@ -74,11 +78,21 @@ TodosList.propTypes = {
   onDragEnd: PropTypes.func.isRequired,
   reminders: PropTypes.objectOf(PropTypes.string),
   handleSaveReminder: PropTypes.func.isRequired,
+  listMembers: PropTypes.arrayOf(PropTypes.string),
+  memberDetails: PropTypes.objectOf(PropTypes.shape({
+    displayName: PropTypes.string,
+  })),
+  onAssign: PropTypes.func,
+  isSharedList: PropTypes.bool,
 };
 
 TodosList.defaultProps = {
   activeCommentId: null,
   reminders: {},
+  listMembers: [],
+  memberDetails: {},
+  onAssign: () => {},
+  isSharedList: false,
 };
 
 export default TodosList;

--- a/src/components/TodosLogic.jsx
+++ b/src/components/TodosLogic.jsx
@@ -13,6 +13,8 @@ import { toast, ToastContainer } from 'react-toastify';
 import DOMPurify from 'dompurify';
 import notificationSound from 'utils/notificationSound';
 import CloudStorageService from '../firebase/cloudStorage';
+import SharedListsService from '../firebase/sharedListsService';
+import SharedListsPanel from './SharedListsPanel';
 import 'react-toastify/dist/ReactToastify.css';
 
 const TodosLogic = ({
@@ -29,19 +31,85 @@ const TodosLogic = ({
   const [isLoadingFromCloud, setIsLoadingFromCloud] = useState(true);
   const [hasLoadedInitialData, setHasLoadedInitialData] = useState(false);
 
+  // Shared lists state
+  const [activeList, setActiveList] = useState({ id: 'personal', name: 'My Tasks', type: 'personal' });
+  const [listMembers, setListMembers] = useState([]);
+
   const cloudServiceRef = useRef(null);
+  const sharedListsServiceRef = useRef(null);
   const savingToCloudRef = useRef(false);
+  const sharedListUnsubscribeRef = useRef(null);
+  const pendingLocalChangesRef = useRef(false);
+
+  // State for member details (email -> displayName mapping)
+  const [memberDetails, setMemberDetails] = useState({});
 
   // Initialize cloud service
   useEffect(() => {
     if (!cloudServiceRef.current) {
       cloudServiceRef.current = new CloudStorageService('anonymous');
     }
-  }, []);
+    if (!sharedListsServiceRef.current && currentUser?.email) {
+      sharedListsServiceRef.current = new SharedListsService(
+        currentUser.email,
+        currentUser.displayName,
+      );
+    } else if (sharedListsServiceRef.current && currentUser?.displayName) {
+      sharedListsServiceRef.current.setUserDisplayName(currentUser.displayName);
+    }
+  }, [currentUser]);
 
-  // Load initial data from cloud - runs on mount and when user changes
+  // Load initial data from cloud - runs on mount and when user or active list changes
   useEffect(() => {
     const loadData = async () => {
+      // Cleanup previous shared list subscription
+      if (sharedListUnsubscribeRef.current) {
+        sharedListUnsubscribeRef.current();
+        sharedListUnsubscribeRef.current = null;
+      }
+
+      setIsLoadingFromCloud(true);
+      setHasLoadedInitialData(false);
+
+      // If it's a shared list, subscribe to it
+      if (activeList.type === 'shared' && sharedListsServiceRef.current) {
+        // Update current user's display name in the list
+        sharedListsServiceRef.current.updateMyDisplayName(activeList.id);
+
+        // Track if we've received initial data for this list
+        let receivedInitialData = false;
+
+        sharedListUnsubscribeRef.current = sharedListsServiceRef.current.subscribeToList(
+          activeList.id,
+          (result) => {
+            // On first load, always accept the data
+            // Only skip if we have pending local changes AND already received initial data
+            if (pendingLocalChangesRef.current && receivedInitialData) {
+              // eslint-disable-next-line no-console
+              console.log('Skipping subscription update: pending local changes');
+              return;
+            }
+            if (result.success && result.data) {
+              setTodos(result.data.todos || []);
+              setComments(result.data.comments || {});
+              setReminders(result.data.reminders || {});
+              setListMembers(result.data.members || []);
+              setMemberDetails(result.data.memberDetails || {});
+              // Points are personal, not shared
+              receivedInitialData = true;
+            }
+            setHasLoadedInitialData(true);
+            setIsLoadingFromCloud(false);
+          },
+        );
+        return;
+      }
+
+      // Personal list - clear members
+      setListMembers([]);
+      setMemberDetails({});
+
+      // Personal list - use cloud storage service
       if (!cloudServiceRef.current) {
         setIsLoadingFromCloud(false);
         return;
@@ -72,7 +140,14 @@ const TodosLogic = ({
     };
 
     loadData();
-  }, [currentUser]);
+
+    // Cleanup on unmount or when dependencies change
+    return () => {
+      if (sharedListUnsubscribeRef.current) {
+        sharedListUnsubscribeRef.current();
+      }
+    };
+  }, [currentUser, activeList]);
 
   // Request notification permission on mount (with error handling for mobile)
   useEffect(() => {
@@ -219,6 +294,17 @@ const TodosLogic = ({
     );
   };
 
+  const handleAssign = (todoId, assignee) => {
+    setTodos(
+      todos.map((todo) => {
+        if (todo.id === todoId) {
+          return { ...todo, assignedTo: assignee };
+        }
+        return todo;
+      }),
+    );
+  };
+
   const onDragEnd = (result) => {
     if (!result.destination) return;
 
@@ -230,6 +316,11 @@ const TodosLogic = ({
   };
 
   useEffect(() => {
+    // Mark that we have pending local changes as soon as state changes
+    if (hasLoadedInitialData && activeList.type === 'shared') {
+      pendingLocalChangesRef.current = true;
+    }
+
     const saveToCloud = async () => {
       // CRITICAL: Don't save until we have successfully loaded initial data
       // This prevents overwriting cloud data with empty state during initialization
@@ -239,29 +330,41 @@ const TodosLogic = ({
         return;
       }
 
-      if (isLoadingFromCloud || savingToCloudRef.current || !cloudServiceRef.current) return;
+      if (isLoadingFromCloud || savingToCloudRef.current) return;
 
       savingToCloudRef.current = true;
 
       try {
-        await cloudServiceRef.current.saveAllData({
-          todos,
-          comments,
-          reminders,
-          points,
-        });
+        // Save to shared list or personal list based on active list
+        if (activeList.type === 'shared' && sharedListsServiceRef.current) {
+          await sharedListsServiceRef.current.saveListTodos(activeList.id, todos);
+          await sharedListsServiceRef.current.saveListComments(activeList.id, comments);
+          await sharedListsServiceRef.current.saveListReminders(activeList.id, reminders);
+        } else if (cloudServiceRef.current) {
+          await cloudServiceRef.current.saveAllData({
+            todos,
+            comments,
+            reminders,
+            points,
+          });
+        }
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Auto-save error:', error);
       } finally {
         savingToCloudRef.current = false;
+        // Clear the pending changes flag after save completes
+        // Use a small delay to allow Firestore to propagate the update
+        setTimeout(() => {
+          pendingLocalChangesRef.current = false;
+        }, 500);
       }
     };
 
     // Debounce auto-save by 1 second
     const timeoutId = setTimeout(saveToCloud, 1000);
     return () => clearTimeout(timeoutId);
-  }, [todos, comments, points, reminders, isLoadingFromCloud, hasLoadedInitialData]);
+  }, [todos, comments, points, reminders, isLoadingFromCloud, hasLoadedInitialData, activeList]);
 
   useEffect(() => {
     const checkReminders = () => {
@@ -419,9 +522,49 @@ const TodosLogic = ({
     onPageChange(1); // Reset to first page when searching
   };
 
+  // Handle list selection
+  const handleListSelect = (list) => {
+    setActiveList(list);
+    onPageChange(1); // Reset to first page when switching lists
+    setActiveTab('active'); // Reset to active tab
+  };
+
   return (
     <>
       <ToastContainer />
+
+      {/* Shared Lists Panel - only show when logged in */}
+      {currentUser && (
+        <SharedListsPanel
+          currentUser={currentUser}
+          activeList={activeList}
+          onListSelect={handleListSelect}
+        />
+      )}
+
+      {/* Current List Indicator */}
+      {activeList.type === 'shared' && (
+        <div style={{
+          padding: '8px 16px',
+          background: '#fff5f5',
+          borderRadius: '8px',
+          marginBottom: '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          fontSize: '14px',
+          color: '#dc4c3e',
+          fontWeight: 500,
+        }}
+        >
+          📋 Viewing:
+          {' '}
+          <strong>{activeList.name}</strong>
+          {' '}
+          (Shared List)
+        </div>
+      )}
+
       {/* Search Bar */}
       <div style={{
         marginBottom: '1rem',
@@ -460,6 +603,10 @@ const TodosLogic = ({
             onDragEnd={onDragEnd}
             reminders={reminders}
             handleSaveReminder={handleSaveReminder}
+            listMembers={listMembers}
+            memberDetails={memberDetails}
+            onAssign={handleAssign}
+            isSharedList={activeList.type === 'shared'}
           />
           <Pagination
             currentPage={currentPage}

--- a/src/firebase/sharedListsService.js
+++ b/src/firebase/sharedListsService.js
@@ -1,0 +1,484 @@
+import {
+  doc,
+  setDoc,
+  getDoc,
+  getDocs,
+  deleteDoc,
+  collection,
+  query,
+  where,
+  onSnapshot,
+  arrayUnion,
+  arrayRemove,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { v4 as uuidv4 } from 'uuid';
+import { db } from './config';
+
+/**
+ * SharedListsService - Manages collaborative todo lists
+ *
+ * Firestore Structure:
+ * - /sharedLists/{listId} - The shared list document
+ *   - id: string
+ *   - name: string
+ *   - owner: string (email)
+ *   - members: string[] (emails)
+ *   - todos: array
+ *   - comments: object
+ *   - reminders: object
+ *   - createdAt: timestamp
+ *   - updatedAt: timestamp
+ *
+ * - /users/{email}/sharedListRefs/{listId} - Reference to shared lists user has access to
+ */
+
+class SharedListsService {
+  constructor(userEmail = null, userDisplayName = null) {
+    this.userEmail = userEmail;
+    this.userDisplayName = userDisplayName;
+  }
+
+  setUserEmail(email) {
+    this.userEmail = email;
+  }
+
+  setUserDisplayName(displayName) {
+    this.userDisplayName = displayName;
+  }
+
+  // Create a new shared list
+  async createList(name) {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated' };
+    }
+
+    try {
+      const listId = uuidv4();
+      const listRef = doc(db, 'sharedLists', listId);
+
+      const listData = {
+        id: listId,
+        name,
+        owner: this.userEmail,
+        members: [this.userEmail],
+        memberDetails: {
+          [this.userEmail]: {
+            displayName: this.userDisplayName || this.userEmail.split('@')[0],
+            addedAt: new Date().toISOString(),
+          },
+        },
+        todos: [],
+        comments: {},
+        reminders: {},
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      };
+
+      await setDoc(listRef, listData);
+
+      // Add reference to user's shared lists
+      await this.addListRefToUser(this.userEmail, listId, name);
+
+      return { success: true, listId, data: listData };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error creating shared list:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Add a reference to a shared list in user's document
+  // eslint-disable-next-line class-methods-use-this
+  async addListRefToUser(email, listId, listName) {
+    try {
+      const userListRef = doc(db, 'users', email, 'sharedListRefs', listId);
+      await setDoc(userListRef, {
+        listId,
+        listName,
+        addedAt: serverTimestamp(),
+      });
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error adding list ref to user:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Remove a reference to a shared list from user's document
+  // eslint-disable-next-line class-methods-use-this
+  async removeListRefFromUser(email, listId) {
+    try {
+      const userListRef = doc(db, 'users', email, 'sharedListRefs', listId);
+      await deleteDoc(userListRef);
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error removing list ref from user:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Get all shared lists the user has access to
+  async getUserSharedLists() {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated', lists: [] };
+    }
+
+    try {
+      const listsQuery = query(
+        collection(db, 'sharedLists'),
+        where('members', 'array-contains', this.userEmail),
+      );
+
+      const snapshot = await getDocs(listsQuery);
+      const lists = snapshot.docs.map((docSnap) => ({
+        id: docSnap.id,
+        ...docSnap.data(),
+      }));
+
+      return { success: true, lists };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error getting shared lists:', error);
+      return { success: false, error: error.message, lists: [] };
+    }
+  }
+
+  // Get a specific shared list
+  async getList(listId) {
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (docSnap.exists()) {
+        const data = docSnap.data();
+        // Check if user has access
+        if (data.members.includes(this.userEmail)) {
+          return { success: true, data };
+        }
+        return { success: false, error: 'Access denied' };
+      }
+      return { success: false, error: 'List not found' };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error getting list:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Invite a member to a shared list
+  async inviteMember(listId, memberEmail, memberDisplayName = null) {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated' };
+    }
+
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (!docSnap.exists()) {
+        return { success: false, error: 'List not found' };
+      }
+
+      const listData = docSnap.data();
+
+      // Check if current user is owner or member
+      if (!listData.members.includes(this.userEmail)) {
+        return { success: false, error: 'Access denied' };
+      }
+
+      // Check if member is already in the list
+      if (listData.members.includes(memberEmail)) {
+        return { success: false, error: 'User is already a member' };
+      }
+
+      // Build memberDetails update
+      const memberDetails = listData.memberDetails || {};
+      memberDetails[memberEmail] = {
+        displayName: memberDisplayName || memberEmail.split('@')[0],
+        addedAt: new Date().toISOString(),
+      };
+
+      // Add member to the list
+      await setDoc(listRef, {
+        members: arrayUnion(memberEmail),
+        memberDetails,
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+
+      // Add list reference to the new member's document
+      await this.addListRefToUser(memberEmail, listId, listData.name);
+
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error inviting member:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Remove a member from a shared list
+  async removeMember(listId, memberEmail) {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated' };
+    }
+
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (!docSnap.exists()) {
+        return { success: false, error: 'List not found' };
+      }
+
+      const listData = docSnap.data();
+
+      // Only owner can remove members (except self)
+      if (listData.owner !== this.userEmail && memberEmail !== this.userEmail) {
+        return { success: false, error: 'Only owner can remove members' };
+      }
+
+      // Owner cannot be removed
+      if (memberEmail === listData.owner) {
+        return { success: false, error: 'Cannot remove owner from list' };
+      }
+
+      // Remove member from the list
+      await setDoc(listRef, {
+        members: arrayRemove(memberEmail),
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+
+      // Remove list reference from the member's document
+      await this.removeListRefFromUser(memberEmail, listId);
+
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error removing member:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Update list name
+  async updateListName(listId, newName) {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated' };
+    }
+
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (!docSnap.exists()) {
+        return { success: false, error: 'List not found' };
+      }
+
+      const listData = docSnap.data();
+
+      // Only owner can rename
+      if (listData.owner !== this.userEmail) {
+        return { success: false, error: 'Only owner can rename the list' };
+      }
+
+      await setDoc(listRef, {
+        name: newName,
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+
+      // Update references for all members
+      const updatePromises = listData.members.map(
+        (member) => this.addListRefToUser(member, listId, newName),
+      );
+      await Promise.all(updatePromises);
+
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error updating list name:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Delete a shared list
+  async deleteList(listId) {
+    if (!this.userEmail) {
+      return { success: false, error: 'User not authenticated' };
+    }
+
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (!docSnap.exists()) {
+        return { success: false, error: 'List not found' };
+      }
+
+      const listData = docSnap.data();
+
+      // Only owner can delete
+      if (listData.owner !== this.userEmail) {
+        return { success: false, error: 'Only owner can delete the list' };
+      }
+
+      // Remove list references from all members
+      const removePromises = listData.members.map(
+        (member) => this.removeListRefFromUser(member, listId),
+      );
+      await Promise.all(removePromises);
+
+      // Delete the list
+      await deleteDoc(listRef);
+
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error deleting list:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Save todos to a shared list
+  // eslint-disable-next-line class-methods-use-this
+  async saveListTodos(listId, todos) {
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      await setDoc(listRef, {
+        todos,
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error saving list todos:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Save comments to a shared list
+  // eslint-disable-next-line class-methods-use-this
+  async saveListComments(listId, comments) {
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      await setDoc(listRef, {
+        comments,
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error saving list comments:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Save reminders to a shared list
+  // eslint-disable-next-line class-methods-use-this
+  async saveListReminders(listId, reminders) {
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      await setDoc(listRef, {
+        reminders,
+        updatedAt: serverTimestamp(),
+      }, { merge: true });
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error saving list reminders:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Update current user's display name in a list's memberDetails
+  async updateMyDisplayName(listId) {
+    if (!this.userEmail || !this.userDisplayName) {
+      return { success: false, error: 'User not authenticated or no display name' };
+    }
+
+    try {
+      const listRef = doc(db, 'sharedLists', listId);
+      const docSnap = await getDoc(listRef);
+
+      if (!docSnap.exists()) {
+        return { success: false, error: 'List not found' };
+      }
+
+      const listData = docSnap.data();
+
+      // Check if user is a member
+      if (!listData.members.includes(this.userEmail)) {
+        return { success: false, error: 'Access denied' };
+      }
+
+      // Update memberDetails with current user's display name
+      const memberDetails = listData.memberDetails || {};
+      const currentDetails = memberDetails[this.userEmail] || {};
+
+      // Only update if display name is different or missing
+      if (currentDetails.displayName !== this.userDisplayName) {
+        memberDetails[this.userEmail] = {
+          ...currentDetails,
+          displayName: this.userDisplayName,
+          updatedAt: new Date().toISOString(),
+        };
+
+        await setDoc(listRef, {
+          memberDetails,
+          updatedAt: serverTimestamp(),
+        }, { merge: true });
+      }
+
+      return { success: true };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error updating display name:', error);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Subscribe to real-time updates for a shared list
+  // eslint-disable-next-line class-methods-use-this
+  subscribeToList(listId, callback) {
+    const listRef = doc(db, 'sharedLists', listId);
+    return onSnapshot(listRef, (docSnap) => {
+      if (docSnap.exists()) {
+        callback({ success: true, data: docSnap.data() });
+      } else {
+        callback({ success: false, error: 'List not found' });
+      }
+    }, (error) => {
+      // eslint-disable-next-line no-console
+      console.error('Error subscribing to list:', error);
+      callback({ success: false, error: error.message });
+    });
+  }
+
+  // Subscribe to user's shared lists (for list panel updates)
+  subscribeToUserLists(callback) {
+    if (!this.userEmail) {
+      callback({ success: false, error: 'User not authenticated', lists: [] });
+      return () => {};
+    }
+
+    const listsQuery = query(
+      collection(db, 'sharedLists'),
+      where('members', 'array-contains', this.userEmail),
+    );
+
+    return onSnapshot(listsQuery, (snapshot) => {
+      const lists = snapshot.docs.map((docSnap) => ({
+        id: docSnap.id,
+        ...docSnap.data(),
+      }));
+      callback({ success: true, lists });
+    }, (error) => {
+      // eslint-disable-next-line no-console
+      console.error('Error subscribing to user lists:', error);
+      callback({ success: false, error: error.message, lists: [] });
+    });
+  }
+}
+
+export default SharedListsService;

--- a/src/styles/SharedLists.module.css
+++ b/src/styles/SharedLists.module.css
@@ -1,0 +1,341 @@
+.sharedListsPanel {
+  padding: 16px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 16px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.createButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #dc4c3e;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.createButton:hover {
+  background: #c43d30;
+}
+
+.listContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.listItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  background: #f8f9fa;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 2px solid transparent;
+}
+
+.listItem:hover {
+  background: #f0f1f2;
+}
+
+.listItem.active {
+  background: #fff5f5;
+  border-color: #dc4c3e;
+}
+
+.listItem.personal {
+  background: #f0f7ff;
+}
+
+.listItem.personal.active {
+  background: #e6f0ff;
+  border-color: #2196f3;
+}
+
+.listInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.listIcon {
+  font-size: 18px;
+}
+
+.listDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.listName {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.listMeta {
+  font-size: 12px;
+  color: #666;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.memberCount {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.todoCount {
+  color: #888;
+}
+
+.listActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.actionButton {
+  padding: 6px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.actionButton:hover {
+  background: rgba(0, 0, 0, 0.1);
+  color: #333;
+}
+
+.ownerBadge {
+  font-size: 10px;
+  padding: 2px 6px;
+  background: #dc4c3e;
+  color: white;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 24px;
+  color: #888;
+}
+
+.emptyState p {
+  margin: 0 0 12px;
+  font-size: 14px;
+}
+
+/* Modal styles */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.modal h3 {
+  margin: 0 0 16px;
+  font-size: 18px;
+  color: #333;
+}
+
+.inputGroup {
+  margin-bottom: 16px;
+}
+
+.inputGroup label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #555;
+}
+
+.inputGroup input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.inputGroup input:focus {
+  outline: none;
+  border-color: #dc4c3e;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.cancelButton {
+  padding: 10px 16px;
+  background: #f0f0f0;
+  color: #333;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.cancelButton:hover {
+  background: #e0e0e0;
+}
+
+.submitButton {
+  padding: 10px 16px;
+  background: #dc4c3e;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.submitButton:hover {
+  background: #c43d30;
+}
+
+.submitButton:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+/* Members list in modal */
+.membersList {
+  margin: 16px 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.memberItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: #f8f9fa;
+  border-radius: 6px;
+  margin-bottom: 6px;
+}
+
+.memberEmail {
+  font-size: 14px;
+  color: #333;
+}
+
+.membersLabel {
+  font-size: 14px;
+  font-weight: 500;
+  color: #555;
+}
+
+.removeButton {
+  padding: 4px 8px;
+  background: #ff6b6b;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.removeButton:hover {
+  background: #ee5a5a;
+}
+
+.removeButton:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+/* Collapsible panel */
+.toggleButton {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  transition: background 0.2s;
+}
+
+.toggleButton:hover {
+  background: #f0f1f2;
+}
+
+.toggleIcon {
+  transition: transform 0.2s;
+}
+
+.toggleIcon.open {
+  transform: rotate(180deg);
+}
+
+.panelContent {
+  margin-top: 12px;
+}
+
+.panelContent.collapsed {
+  display: none;
+}

--- a/src/styles/TodoItem.module.css
+++ b/src/styles/TodoItem.module.css
@@ -355,8 +355,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   z-index: 1000;
   min-width: 180px;
-  overflow: visible;
-  max-height: 400px;
+  max-height: 80vh;
   overflow-y: auto;
 }
 
@@ -397,6 +396,56 @@
 .reminderInMenu {
   padding: 8px 16px;
   border-top: 1px solid #f0f0f0;
+}
+
+/* Assign task submenu */
+.assignMenuWrapper {
+  width: 100%;
+}
+
+.assignSubmenu {
+  background: #f5f5f5;
+  border-top: 1px solid #e0e0e0;
+  padding: 4px 0;
+  margin: 0;
+}
+
+.assignSubmenu button {
+  display: block;
+  width: 100%;
+  padding: 8px 16px 8px 36px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  color: #555;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.assignSubmenu button:hover {
+  background: #e8e8e8;
+}
+
+.activeAssignee {
+  background: #d4edda !important;
+  color: #155724 !important;
+  font-weight: 600;
+}
+
+.assignedBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  margin-left: 8px;
+  background: #e3f2fd;
+  color: #1565c0;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
 }
 
 @media (max-width: 600px) {

--- a/src/styles/githubDarkDimmed.js
+++ b/src/styles/githubDarkDimmed.js
@@ -17,7 +17,7 @@ const githubDarkDimmed = {
   },
   'pre[class*="language-"]': {
     color: '#adbac7',
-    background: '#2b3038ff',
+    background: '#b1d8c9ff',
     fontFamily: "'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
     textAlign: 'left',
     whiteSpace: 'pre',
@@ -58,13 +58,13 @@ const githubDarkDimmed = {
     color: '#8ddb8c',
   },
   boolean: {
-    color: '#6cb6ff',
+    color: '#a72ea7ff',
   },
   number: {
     color: '#6cb6ff',
   },
   constant: {
-    color: '#6cb6ff',
+    color: '#ec1616ff',
   },
   symbol: {
     color: '#6cb6ff',


### PR DESCRIPTION
- Add SharedListsService for managing shared lists in Firestore
- Add SharedListsPanel UI component for creating and managing lists
- Add task assignment feature with member dropdown
- Display assignee names using memberDetails (display names)
- Update Firestore rules to support shared lists and member invitations
- Fix race condition with pending local changes flag
- Auto-update user display names when accessing shared lists
- Fix dropdown positioning for bottom-of-screen tasks
- Add inline assign submenu styling